### PR TITLE
Enable DELETE functionality for clients API endpoint

### DIFF
--- a/core/views_main.py
+++ b/core/views_main.py
@@ -474,7 +474,7 @@ class AdvisorClientListView(generics.ListAPIView):
         return queryset
     
   
-class ClientDetailView(generics.RetrieveAPIView):
+class ClientDetailView(generics.RetrieveDestroyAPIView):
     queryset = Client.objects.all()
     serializer_class = ClientDetailSerializer
     permission_classes = [permissions.IsAuthenticated]


### PR DESCRIPTION
- Changed ClientDetailView from RetrieveAPIView to RetrieveDestroyAPIView
- Allows advisors to delete their own clients
- Maintains existing permission checks

🤖 Generated with [Claude Code](https://claude.ai/code)